### PR TITLE
add "error_raised" in api

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ defining test cases, test suites, set of build-in assertions, configurable tests
 ### Top features that are not present in other lua test frameworks
 1. Nice command line interface (like gtest).
 1. Backtrace in failed assertions.
-1. Ordered test execution (as written in source file). 
+1. Ordered test execution (as written in source file).
 1. Support 5.1/5.2/5.3 and LuaJIT.
 1. Select particular tests with regexp.
 
@@ -33,14 +33,14 @@ test.hello_world = function ()
     test.assert(1 ~= 2)
 end
 
--- This is how you can crete your first test case 
+-- This is how you can create your first test case
 test.addition = function ()
     test.equal(1 + 1, 2)
     test.not_equal("1 + 1", "2")
     test.almost_equal(1 + 1, 2.1, 0.2)
 end
 
--- You can enable custom start_up and tear_down actions 
+-- You can enable custom start_up and tear_down actions
 -- Thse actions will be invoked:
 -- start_up - before test case
 -- tear_down - after test case
@@ -79,7 +79,7 @@ local global_table = {}
 test.table.start_up = function ()
     global_table = { 1, 2, "three", 4, "five" }
 end
-test.table.tear_down = function () 
+test.table.tear_down = function ()
     global_table = {}
 end
 
@@ -87,7 +87,7 @@ test.table.concat = function ()
     test.equal(table.concat(global_table, ", "), "1, 2, three, 4, five")
 end
 
--- you can disabe broken test case like this
+-- you can disable broken test case like this
 test.broken.skip = true
 test.broken.bad_case = function ()
     test.equal(1, 2)
@@ -119,4 +119,5 @@ test.is_number(3)
 test.is_table({"I am table now"})
 test.is_function(function () end)
 test.is_userdata(userdata_value)
+test.error_raised(function() error("error 10") end, "error 10")
 ```

--- a/example.lua
+++ b/example.lua
@@ -6,14 +6,14 @@ test.hello_world = function ()
     test.assert(1 ~= 2)
 end
 
--- This is how you can crete your first test case 
+-- This is how you can create your first test case
 test.addition = function ()
     test.equal(1 + 1, 2)
     test.not_equal("1 + 1", "2")
     test.almost_equal(1 + 1, 2.1, 0.2)
 end
 
--- You can enable custom start_up and tear_down actions 
+-- You can enable custom start_up and tear_down actions
 -- Thse actions will be invoked:
 -- start_up - before test case
 -- tear_down - after test case
@@ -52,7 +52,7 @@ local global_table = {}
 test.table.start_up = function ()
     global_table = { 1, 2, "three", 4, "five" }
 end
-test.table.tear_down = function () 
+test.table.tear_down = function ()
     global_table = {}
 end
 
@@ -60,7 +60,7 @@ test.table.concat = function ()
     test.equal(table.concat(global_table, ", "), "1, 2, three, 4, five")
 end
 
--- you can disabe broken test case like this
+-- you can disable broken test case like this
 test.broken.skip = true
 test.broken.bad_case = function ()
     test.equal(1, 2)

--- a/internal-api-check.lua
+++ b/internal-api-check.lua
@@ -20,6 +20,7 @@ t.all_assertions = function ()
     t.is_table({})
     t.is_function(function() end)
     t.is_thread(coroutine.create(function () end))
+    t.error_raised(function() error("") end)
 end
 
 local function fail_all()
@@ -37,6 +38,7 @@ local function fail_all()
     t.is_table()
     t.is_function(coroutine.create(function () end))
     t.is_thread(function() end)
+    t.error_raised(function() end)
 end
 
 t.all_assertions_failed = function ()
@@ -88,6 +90,24 @@ t.tests_result = function()
         t.equal(ntests, 7)
         t.equal(nfailed, 2)
     end
+end
+
+t.test_error_raised.when_error_is_raised = function()
+    t.error_raised(function() error("a custom error") end)
+end
+
+t.test_error_raised.with_error_message = function()
+    t.error_raised(function() error("a custom error") end,
+        "custom error")
+end
+
+t.test_error_raised.with_wrong_error_message = function()
+    t.error_raised(function() error("another error") end,
+        "custom error")
+end
+
+t.test_error_raised.when_error_is_not_raised = function()
+    t.error_raised(function() end)
 end
 
 t.summary()

--- a/u-test.lua
+++ b/u-test.lua
@@ -136,6 +136,20 @@ api.is_not_nil = function (maybe_not_nil)
     end
 end
 
+api.error_raised = function (f, error_message, ...)
+    local status, err = pcall(f, ...)
+    if status == true then
+        fail("error not raised")
+    else
+        if error_message ~= nil then
+            -- we set "plain" to true to avoid pattern matching in string.find
+            if err:find(error_message, 1, true) == nil then
+                fail("'" .. error_message .. "' not found in error '" .. tostring(err) .. "'")
+            end
+        end
+    end
+end
+
 local function make_type_checker(typename)
     api["is_" .. typename] = function (maybe_type)
         if type(maybe_type) ~= typename then


### PR DESCRIPTION
Hello,

This PR adds one function to u-test API: "error_raised". It checks that an error has been raised during the execution of a function: `test.error_raised(function() error("something went wrong") end)`

It can also check for a specific error message: `test.error_raised(function() error("this is the error no 23") end, "error no 23")`. In this case, it tries to find a specific string in the actual error message.

I took the liberty of correcting some typos, I hope that's okay.

Have a good day