### PR TITLE
Register custom assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,20 @@ test.is_function(function () end)
 test.is_userdata(userdata_value)
 test.error_raised(function() error("error 10") end, "error 10")
 ```
+
+### Custom assertions
+
+```lua
+local function is_elephant(animal)
+    if animal ~= "elephant" then
+        local failure_msg = "Expected elephant, but got "..tostring(animal)
+        return false, msg
+    end
+
+    return true
+end
+
+test.register_assert("is_elephant", is_elephant)
+
+test.is_elephant("dolphin") -- fails!
+```

--- a/internal-api-check.lua
+++ b/internal-api-check.lua
@@ -110,4 +110,29 @@ t.test_error_raised.when_error_is_not_raised = function()
     t.error_raised(function() end)
 end
 
+
+local function has_key(tab, key)
+    local msg
+    if type(tab) ~= "table" then
+        msg = "Expected first argument to be table"
+        return false, msg
+    end
+
+    if tab[key] == nil then
+        msg = "Expected table to have key '"..tostring(key).."'"
+        return false, msg
+    end
+
+    return true
+end
+
+t.register_assert("has_key", has_key)
+
+t.test_if_table_has_key = function(tab, key)
+    t.has_key(tab, key)
+end
+
+t.test_if_table_has_key({ name = "John" }, "name")
+t.test_if_table_has_key({ name = "John" }, "age")
+
 t.summary()

--- a/u-test.lua
+++ b/u-test.lua
@@ -150,6 +150,16 @@ api.error_raised = function (f, error_message, ...)
     end
 end
 
+api.register_assert = function(assert_name, assert_func)
+    api[assert_name] = function(...)
+        local result, msg = assert_func(...)
+        if not result then
+            msg = msg or "Assertion "..assert_name.." failed"
+            fail(msg)
+        end
+    end
+end
+
 local function make_type_checker(typename)
     api["is_" .. typename] = function (maybe_type)
         if type(maybe_type) ~= typename then

--- a/u-test.lua
+++ b/u-test.lua
@@ -151,13 +151,13 @@ api.error_raised = function (f, error_message, ...)
 end
 
 api.register_assert = function(assert_name, assert_func)
-    api[assert_name] = function(...)
+    rawset(api, assert_name, function(...)
         local result, msg = assert_func(...)
         if not result then
             msg = msg or "Assertion "..assert_name.." failed"
             fail(msg)
         end
-    end
+    end)
 end
 
 local function make_type_checker(typename)


### PR DESCRIPTION
Added `register_assert()` function to allow custom assertions. 
Optionally, instead of using this function the `fail()` function could be made part of the public api.