### PR TITLE
Modify stringize_var_arg to print nil and false args

### DIFF
--- a/u-test.lua
+++ b/u-test.lua
@@ -74,7 +74,11 @@ local function stringize_var_arg(...)
     local args = { n = select("#", ...), ... }
     local result = {}
     for i = 1, args.n do
-        result[i] = tostring(args[i])
+        if type(args[i]) == 'string' then
+            result[i] = '"' .. tostring(args[i]) .. '"'
+        else
+            result[i] = tostring(args[i])
+        end
     end
     return table.concat(result, ", ")
 end

--- a/u-test.lua
+++ b/u-test.lua
@@ -70,17 +70,13 @@ local function fail(msg, start_frame)
     trace(start_frame or 4)
 end
 
-local function stringize_var_arg(varg, ...)
-    if varg then
-        local rest = stringize_var_arg(...)
-        if rest ~= "" then
-            return tostring(varg) .. ", ".. rest
-        else
-            return tostring(varg)
-        end
-    else
-        return ""
+local function stringize_var_arg(...)
+    local args = { n = select("#", ...), ... }
+    local result = {}
+    for i = 1, args.n do
+        result[i] = tostring(args[i])
     end
+    return table.concat(result, ", ")
 end
 
 local function test_pretty_name(suite_name, test_name)


### PR DESCRIPTION
When summarizing a test suite case with parameters, nil and false parameters are not printed. e.g. `test.string.starts_with("Lua rocks", nil, 1)` prints `test.string.starts_with(Lua rocks)`

I changed it to use the `select` function to calculate the actual number of arguments. The same could be done with `table.pack` but I don't think that's available in Lua 5.1.

Thanks for the wonderful testing framework!